### PR TITLE
Added handling for the colon character

### DIFF
--- a/src/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandler.php
+++ b/src/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandler.php
@@ -397,7 +397,13 @@ function $funcName {
         exit $?;
     fi;
 
-    COMPREPLY=(`compgen -W "\$RESULT"`);
+    local cur;
+    _get_comp_words_by_ref -n : cur;
+
+    COMPREPLY=(`compgen -W "\$RESULT" -- \$cur`);
+
+    __ltrim_colon_completions "\$cur";
+
 };
 complete -F $funcName $programName;
 END;


### PR DESCRIPTION
It is common to group commands into namespaces by using a colon in the command name to separate them.
However standard bash completion treats the colon as a wordbreak (useful for ssh/scp)
This change allows bash completion to work with commands including a colon character
Based on the answer from this stack overflow quetion:
http://stackoverflow.com/questions/10528695/how-to-reset-comp-wordbreaks-without-effecting-other-completion-script
