### PR TITLE
Allow methods as callbacks.

### DIFF
--- a/src/Completion.php
+++ b/src/Completion.php
@@ -60,13 +60,10 @@ class Completion {
      */
     public function run()
     {
-        if (is_array($this->completion)) {
-            return $this->completion;
-        }
-
         if ($this->isCallable()) {
             return call_user_func($this->completion);
         }
+        return (array) $this->completion;
     }
 
     /**


### PR DESCRIPTION
A callback in PHP can legitimately be an array, such as `array($object, 'myMethod')` or `array('className', 'myStaticMethod')`. `Completion::run()` didn't allow this because it interpreted the callback directly as an array of results.
