### PR TITLE
Suppress exceptions

### DIFF
--- a/src/Completion.php
+++ b/src/Completion.php
@@ -36,6 +36,12 @@ class Completion {
      */
     protected $completion;
 
+    /**
+     * Suppress exceptions during auto-completion.
+     * @var bool
+     */
+    protected $suppressExceptions = true;
+
     public static function makeGlobalHandler($targetName, $type, $completion)
     {
         return new Completion(self::ALL_COMMANDS, $targetName, $type, $completion);
@@ -54,6 +60,11 @@ class Completion {
         return $this->commandName == '';
     }
 
+    public function suppressExceptions($suppress = true)
+    {
+        $this->suppressExceptions = $suppress;
+    }
+
     /**
      * Return the result of the completion helper
      * @return array|mixed
@@ -64,7 +75,9 @@ class Completion {
             try {
               return call_user_func($this->completion);
             } catch (\Exception $e) {
-              // Always suppress exceptions from the callback.
+              if (!$this->suppressExceptions) {
+                throw $e;
+              }
               return array();
             }
         }


### PR DESCRIPTION
It's quite disruptive to see an exception on the command line while auto-completion is running. Exceptions should be suppressed somehow.

Obviously this could happen inside the callback itself. However, doing it inside `Completion::run()` seems appropriate - for [my use case](https://github.com/platformsh/platformsh-cli/pull/158/files), the suppression is only necessary during auto-completion, so the integration code is full of try/catch blocks.
