### PR TITLE
Check if bash_completion is installed.

### DIFF
--- a/src/HookFactory.php
+++ b/src/HookFactory.php
@@ -51,7 +51,9 @@ function %%function_name%% {
     __ltrim_colon_completions "$cur";
 };
 
-complete -F %%function_name%% %%program_name%%;
+if command -v _get_comp_words_by_ref >/dev/null 2>&1; then
+    complete -F %%function_name%% %%program_name%%;
+fi
 END
 
         // ZSH Hook


### PR DESCRIPTION
I'm not sure if this is the right approach, but this is to avoid these kinds of errors on (weird) Bash shells when bash-completion is not installed.

```
-bash: _get_comp_words_by_ref: command not found
-bash: __ltrim_colon_completions: command not found
```
