### PR TITLE
Ignore user-specific PHPUnit config file and build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor
 .idea
+/build/
+phpunit.xml


### PR DESCRIPTION
If user needs to change PHPUnit config file (the `phpunit.xml.dist`) the common practice is to create `phpunit.xml` file with user specific options.

Currently this file shows as uncommited. This PR adds it to `.gitignore`. Also the `build` folder, that potentially can contain build-specific artefacts like converage reports is ignored now.