### PR TITLE
Make all completion related method return empty array for no completions

### DIFF
--- a/src/Completion.php
+++ b/src/Completion.php
@@ -48,14 +48,15 @@ class Completion implements CompletionInterface
 
     /**
      * Return the result of the completion helper
-     * @return array|mixed
+     * @return array
      */
     public function run()
     {
         if ($this->isCallable()) {
             return call_user_func($this->completion);
         }
-        return (array) $this->completion;
+
+        return $this->completion;
     }
 
     /**

--- a/src/Completion/CompletionInterface.php
+++ b/src/Completion/CompletionInterface.php
@@ -44,7 +44,7 @@ interface CompletionInterface
      *
      * Returns an array of possible completions or null to indicate that no completions are available.
      *
-     * @return array|null
+     * @return array
      */
     public function run();
 }

--- a/src/CompletionHandler.php
+++ b/src/CompletionHandler.php
@@ -54,9 +54,9 @@ class CompletionHandler
     }
 
     /**
-     * @param array|Completion $array
+     * @param Completion[] $array
      */
-    public function addHandlers($array)
+    public function addHandlers(array $array)
     {
         $this->helpers = array_merge($this->helpers, $array);
     }
@@ -92,9 +92,11 @@ class CompletionHandler
         );
 
         foreach ($process as $methodName) {
-            if (is_array($result = $this->{$methodName}())) {
+            $result = $this->{$methodName}();
+
+            if (false !== $result) {
                 // Return the result of the first completion mode that matches
-                return $this->filterResults($result);
+                return $this->filterResults((array) $result);
             }
         }
 
@@ -284,11 +286,13 @@ class CompletionHandler
                 }
             }
         }
+
+        return null;
     }
 
     /**
      * @param InputOption $option
-     * @return array|mixed
+     * @return array|false
      */
     protected function completeOption(InputOption $option)
     {
@@ -299,6 +303,8 @@ class CompletionHandler
         if ($this->command instanceof CompletionAwareInterface) {
             return $this->command->completeOptionValues($option->getName(), $this->context);
         }
+
+        return false;
     }
 
     /**
@@ -331,7 +337,6 @@ class CompletionHandler
         }
 
         foreach ($this->context->getWords() as $wordIndex => $word) {
-
             // Skip program name, command name, options, and option values
             if ($wordIndex < 2
                 || ($word && '-' === $word[0])
@@ -369,6 +374,11 @@ class CompletionHandler
         });
     }
 
+    /**
+     * Returns list of all options.
+     *
+     * @return InputOption[]
+     */
     protected function getAllOptions()
     {
         return array_merge(


### PR DESCRIPTION
I've also changed PHPDoc of `CompletionInterface` (removed `null` part) because I belive that method return type should be consistent. If we're returning possible option/argument values, then no values means empty array instead special `null` to indicate that.