### PR TITLE
Adding branch alias for composer for version constrain matching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "stecman/symfony-console-completion",
     "description": "Automatic BASH completion for Symfony Console Component based applications.",
-	"license": "MIT",
+    "license": "MIT",
     "authors": [
         {
             "name": "Stephen Holdaway",
@@ -18,6 +18,11 @@
     "autoload": {
         "psr-4": {
             "Stecman\\Component\\Symfony\\Console\\BashCompletion\\": "src/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.4.x-dev"
         }
     }
 }


### PR DESCRIPTION
With branch alias specified it's now possible to use library with `~0.4@dev` version constrain, which will use `master` branch unless project stability is forced to stable.

More info at https://getcomposer.org/doc/articles/aliases.md .