### PR TITLE
Support command argument/option completion, when command short form is used

### DIFF
--- a/src/CompletionHandler.php
+++ b/src/CompletionHandler.php
@@ -82,8 +82,11 @@ class CompletionHandler
         }
 
         $cmdName = $this->getInput()->getFirstArgument();
-        if ($this->application->has($cmdName)) {
-            $this->command = $this->application->get($cmdName);
+
+        try {
+            $this->command = $this->application->find($cmdName);
+        } catch (\InvalidArgumentException $e) {
+            // Exception thrown, when multiple or none commands are found.
         }
 
         $process = array(

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
@@ -131,4 +131,16 @@ class CompletionHandlerTest extends CompletionHandlerTestCase
             ),
         );
     }
+
+    public function testShortCommandMatched()
+    {
+        $handler = $this->createHandler('app w:n --deploy');
+        $this->assertEquals(array('--deploy:jazz-hands'), $this->getTerms($handler->runCompletion()));
+    }
+
+    public function testShortCommandNotMatched()
+    {
+        $handler = $this->createHandler('app w --deploy');
+        $this->assertEquals(array(), $this->getTerms($handler->runCompletion()));
+    }
 }


### PR DESCRIPTION
When command is named `deploy:run` than same auto-complete results will be shown for any of these:

* `program deploy:run TAB`
* `program d:r TAB`
* `program de:r TAB`
* `program d:ru TAB`

Before this PR only 1st command auto-complete will work.

Closes #38