### PR TITLE
Auto-complete arguments of built-in "help" and "list" commands

### DIFF
--- a/src/CompletionCommand.php
+++ b/src/CompletionCommand.php
@@ -94,7 +94,7 @@ END
      */
     protected function configureCompletion(CompletionHandler $handler)
     {
-         // Override this method to configure custom value completions
+        // Override this method to configure custom value completions
     }
 
     /**

--- a/src/CompletionHandler.php
+++ b/src/CompletionHandler.php
@@ -38,6 +38,24 @@ class CompletionHandler
     {
         $this->application = $application;
         $this->context = $context;
+
+        $this->addHandler(
+            new Completion(
+                'help',
+                'command_name',
+                Completion::TYPE_ARGUMENT,
+                array_keys($application->all())
+            )
+        );
+
+        $this->addHandler(
+            new Completion(
+                'list',
+                'namespace',
+                Completion::TYPE_ARGUMENT,
+                $application->getNamespaces()
+            )
+        );
     }
 
     public function setContext(CompletionContext $context)

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
@@ -143,4 +143,22 @@ class CompletionHandlerTest extends CompletionHandlerTestCase
         $handler = $this->createHandler('app w --deploy');
         $this->assertEquals(array(), $this->getTerms($handler->runCompletion()));
     }
+
+    public function testHelpCommandCompletion()
+    {
+        $handler = $this->createHandler('app help ');
+        $this->assertEquals(
+            array('help', 'list', 'completion-aware', 'wave', 'walk:north'),
+            $this->getTerms($handler->runCompletion())
+        );
+    }
+
+    public function testListCommandCompletion()
+    {
+        $handler = $this->createHandler('app list ');
+        $this->assertEquals(
+            array('walk'),
+            $this->getTerms($handler->runCompletion())
+        );
+    }
 }


### PR DESCRIPTION
Support for completing following:

* `command_name` argument of `help` command
* `namespace` argument of `list` command

Closes #40