### PR TITLE
Allow `_completion` command to auto-complete it's arguments or their values

### DIFF
--- a/src/CompletionCommand.php
+++ b/src/CompletionCommand.php
@@ -3,6 +3,7 @@
 namespace Stecman\Component\Symfony\Console\BashCompletion;
 
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,6 +20,7 @@ class CompletionCommand extends SymfonyCommand
     {
         $this
             ->setName('_completion')
+            ->setDefinition($this->createDefinition())
             ->setDescription('BASH completion hook.')
             ->setHelp(<<<END
 To enable BASH completion, run:
@@ -30,25 +32,15 @@ Or for an alias:
     <comment>eval `[program] _completion -g -p [alias]`</comment>.
 
 END
-            )
-            ->addOption(
-                'generate-hook',
-                'g',
-                InputOption::VALUE_NONE,
-                'Generate BASH code that sets up completion for this application.'
-            )
-            ->addOption(
-                'program',
-                'p',
-                InputOption::VALUE_REQUIRED,
-                "Program name that should trigger completion\n<comment>(defaults to the absolute application path)</comment>."
-            )
-            ->addOption(
-                'shell-type',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Set the shell type (zsh or bash). Otherwise this is determined automatically.'
             );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNativeDefinition()
+    {
+        return $this->createDefinition();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -109,5 +101,29 @@ END
         }
 
         return basename(getenv('SHELL'));
+    }
+
+    protected function createDefinition()
+    {
+        return new InputDefinition(array(
+            new InputOption(
+                'generate-hook',
+                'g',
+                InputOption::VALUE_NONE,
+                'Generate BASH code that sets up completion for this application.'
+            ),
+            new InputOption(
+                'program',
+                'p',
+                InputOption::VALUE_REQUIRED,
+                "Program name that should trigger completion\n<comment>(defaults to the absolute application path)</comment>."
+            ),
+            new InputOption(
+                'shell-type',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Set the shell type (zsh or bash). Otherwise this is determined automatically.'
+            ),
+        ));
     }
 }

--- a/src/CompletionHandler.php
+++ b/src/CompletionHandler.php
@@ -177,7 +177,7 @@ class CompletionHandler
         $word = $this->context->getCurrentWord();
 
         if (strpos($word, '-') === 0 && strlen($word) == 2) {
-            $definition = $this->command ? $this->command->getDefinition() : $this->application->getDefinition();
+            $definition = $this->command ? $this->command->getNativeDefinition() : $this->application->getDefinition();
 
             if ($definition->hasShortcut(substr($word, 1))) {
                 return array($word);
@@ -202,7 +202,7 @@ class CompletionHandler
             // Complete short options
             if ($left[0] == '-' && strlen($left) == 2) {
                 $shortcut = substr($left, 1);
-                $def = $this->command->getDefinition();
+                $def = $this->command->getNativeDefinition();
 
                 if (!$def->hasShortcut($shortcut)) {
                     return false;
@@ -232,7 +232,7 @@ class CompletionHandler
 
             if (strpos($left, '--') === 0) {
                 $name = substr($left, 2);
-                $def = $this->command->getDefinition();
+                $def = $this->command->getNativeDefinition();
 
                 if (!$def->hasOption($name)) {
                     return false;
@@ -279,7 +279,7 @@ class CompletionHandler
     {
         if (strpos($this->context->getCurrentWord(), '-') !== 0) {
             if ($this->command) {
-                $argWords = $this->mapArgumentsToWords($this->command->getDefinition()->getArguments());
+                $argWords = $this->mapArgumentsToWords($this->command->getNativeDefinition()->getArguments());
                 $wordIndex = $this->context->getWordIndex();
 
                 if (isset($argWords[$wordIndex])) {
@@ -433,7 +433,7 @@ class CompletionHandler
         }
 
         return array_merge(
-            $this->command->getDefinition()->getOptions(),
+            $this->command->getNativeDefinition()->getOptions(),
             $this->application->getDefinition()->getOptions()
         );
     }


### PR DESCRIPTION
Right now the `CompletionCommand` has no arguments, but there might be added in #30. In that case without this PR the auto-complete for `app _completion` argument won't work.

In unit tests we're testing all parts separately, but we don't test by really invoking completion hook. That's why I don't know how do I test the changes I've made. All existing tests still pass.

Closes #46