### PR TITLE
Support multi-app completion hook generation (not default behavior)

### DIFF
--- a/src/CompletionCommand.php
+++ b/src/CompletionCommand.php
@@ -53,10 +53,19 @@ END
             $program = $argv[0];
 
             $factory = new HookFactory();
+            $alias = $input->getOption('program');
+            $multiple = (bool)$input->getOption('multiple');
+
+            // When completing for multiple apps having absolute path in the alias doesn't make sense.
+            if (!$alias && $multiple) {
+                $alias = basename($program);
+            }
+
             $hook = $factory->generateHook(
                 $input->getOption('shell-type') ?: $this->getShellType(),
                 $program,
-                $input->getOption('program')
+                $alias,
+                $multiple
             );
 
             $output->write($hook, true);
@@ -117,6 +126,12 @@ END
                 'p',
                 InputOption::VALUE_REQUIRED,
                 "Program name that should trigger completion\n<comment>(defaults to the absolute application path)</comment>."
+            ),
+            new InputOption(
+                'multiple',
+                'm',
+                InputOption::VALUE_NONE,
+                "Generated hook can be used for multiple applications."
             ),
             new InputOption(
                 'shell-type',

--- a/src/HookFactory.php
+++ b/src/HookFactory.php
@@ -114,9 +114,11 @@ END
      * @param string $type - a key from self::$hooks
      * @param string $programPath
      * @param string $programName
+     * @param bool   $multiple
+     *
      * @return string
      */
-    public function generateHook($type, $programPath, $programName = null)
+    public function generateHook($type, $programPath, $programName = null, $multiple = false)
     {
         if (!isset(self::$hooks[$type])) {
             throw new \RuntimeException(sprintf(
@@ -129,6 +131,12 @@ END
         // Use the program path if an alias/name is not given
         $programName = $programName ?: $programPath;
 
+        if ($multiple) {
+            $completionCommand = '${1} _completion';
+        } else {
+            $completionCommand = $programPath . ' _completion';
+        }
+
         return str_replace(
             array(
                 '%%function_name%%',
@@ -140,7 +148,7 @@ END
                 $this->generateFunctionName($programPath, $programName),
                 $programName,
                 $programPath,
-                "$programPath _completion"
+                $completionCommand
             ),
             $this->stripComments(self::$hooks[$type])
         );

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/HookFactoryTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/HookFactoryTest.php
@@ -16,25 +16,40 @@ class HookFactoryTest extends \PHPUnit_Framework_TestCase
         $this->factory = new HookFactory();
     }
 
-    public function testBashSyntax()
+    /**
+     * @dataProvider generateHookDataProvider
+     */
+    public function testBashSyntax($programPath, $programName, $multiple)
     {
         if ($this->hasProgram('bash')) {
-            $script = $this->factory->generateHook('bash', '/path/to/myprogram', 'myprogram');
+            $script = $this->factory->generateHook('bash', $programPath, $programName, $multiple);
             $this->assertSyntaxIsValid($script, 'bash -n', 'BASH hook');
-
         } else {
             $this->markTestSkipped("Couldn't detect BASH program to run hook syntax check");
         }
     }
 
-    public function testZshSyntax()
+    /**
+     * @dataProvider generateHookDataProvider
+     */
+    public function testZshSyntax($programPath, $programName, $multiple)
     {
         if ($this->hasProgram('zsh')) {
-            $script = $this->factory->generateHook('zsh', '/path/to/myprogram', 'myprogram');
+            $script = $this->factory->generateHook('zsh', $programPath, $programName, $multiple);
             $this->assertSyntaxIsValid($script, 'zsh -n', 'ZSH hook');
         } else {
             $this->markTestSkipped("Couldn't detect ZSH program to run hook syntax check");
         }
+    }
+
+    public function generateHookDataProvider()
+    {
+        return array(
+            array('/path/to/myprogram', null, false),
+            array('/path/to/myprogram', null, true),
+            array('/path/to/myprogram', 'myprogram', false),
+            array('/path/to/myprogram', 'myprogram', true),
+        );
     }
 
     protected function hasProgram($programName)


### PR DESCRIPTION
The `--multiple|-m` option is added, that will:

* use `$1` (the path of app user has pressed TAB for) instead of app, for which hook was generated
* imply `--program basename(/absolute/path/to/app)` option, when `--program` option is absent, because when completing for multiple apps the alias should always be present

Usage: `/path/to/app _completion -gm` results in hook generated for `app` alias and works even if you have 2 `app` in different projects.

I've also updated hook factory tests to check syntax for all `generateHook` parameter combinations. Before it was checking syntax for case, when all parameters were given.

Closes #44