### PR TITLE
Support completing array arguments multiple times

### DIFF
--- a/src/CompletionHandler.php
+++ b/src/CompletionHandler.php
@@ -277,23 +277,28 @@ class CompletionHandler
      */
     protected function completeForCommandArguments()
     {
-        if (strpos($this->context->getCurrentWord(), '-') !== 0) {
-            if ($this->command) {
-                $argWords = $this->mapArgumentsToWords($this->command->getNativeDefinition()->getArguments());
-                $wordIndex = $this->context->getWordIndex();
+        if (!$this->command || strpos($this->context->getCurrentWord(), '-') === 0) {
+            return false;
+        }
 
-                if (isset($argWords[$wordIndex])) {
-                    $name = $argWords[$wordIndex];
+        $definition = $this->command->getNativeDefinition();
+        $argWords = $this->mapArgumentsToWords($definition->getArguments());
+        $wordIndex = $this->context->getWordIndex();
 
-                    if ($helper = $this->getCompletionHelper($name, Completion::TYPE_ARGUMENT)) {
-                        return $helper->run();
-                    }
+        if (isset($argWords[$wordIndex])) {
+            $name = $argWords[$wordIndex];
+        } elseif (!empty($argWords) && $definition->getArgument(end($argWords))->isArray()) {
+            $name = end($argWords);
+        } else {
+            return false;
+        }
 
-                    if ($this->command instanceof CompletionAwareInterface) {
-                        return $this->command->completeArgumentValues($name, $this->context);
-                    }
-                }
-            }
+        if ($helper = $this->getCompletionHelper($name, Completion::TYPE_ARGUMENT)) {
+            return $helper->run();
+        }
+
+        if ($this->command instanceof CompletionAwareInterface) {
+            return $this->command->completeArgumentValues($name, $this->context);
         }
 
         return false;

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
@@ -124,6 +124,8 @@ class CompletionHandlerTest extends CompletionHandlerTestCase
             'argument suggestions' => array('app completion-aware any-arg ', array('one-arg', 'two-arg')),
             'argument no suggestions' => array('app completion-aware ', array()),
             'argument suggestions + context' => array('app completion-aware any-arg one', array('one-arg', 'one-arg-context')),
+            'array argument suggestions' => array('app completion-aware any-arg one-arg array-arg1 ', array('one-arg', 'two-arg')),
+            'array argument suggestions + context' => array('app completion-aware any-arg one-arg array-arg1 one', array('one-arg', 'one-arg-context')),
             'option suggestions' => array('app completion-aware --option-with-suggestions ', array('one-opt', 'two-opt')),
             'option no suggestions' => array('app completion-aware --option-without-suggestions ', array()),
             'option suggestions + context' => array(

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/Fixtures/CompletionAwareCommand.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/Fixtures/CompletionAwareCommand.php
@@ -4,6 +4,7 @@
 use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 class CompletionAwareCommand extends Command implements CompletionAwareInterface
@@ -14,7 +15,9 @@ class CompletionAwareCommand extends Command implements CompletionAwareInterface
             ->addOption('option-with-suggestions', null, InputOption::VALUE_REQUIRED)
             ->addOption('option-without-suggestions', null, InputOption::VALUE_REQUIRED)
             ->addArgument('argument-without-suggestions')
-            ->addArgument('argument-with-suggestions');
+            ->addArgument('argument-with-suggestions')
+            ->addArgument('array-argument-with-suggestions', InputArgument::IS_ARRAY)
+        ;
     }
 
     /**
@@ -50,7 +53,7 @@ class CompletionAwareCommand extends Command implements CompletionAwareInterface
      */
     public function completeArgumentValues($argumentName, CompletionContext $context)
     {
-        if ($argumentName === 'argument-with-suggestions') {
+        if (in_array($argumentName, array('argument-with-suggestions', 'array-argument-with-suggestions'))) {
             $suggestions = array('one-arg', 'two-arg');
 
             if ('one' === $context->getCurrentWord()) {


### PR DESCRIPTION
These arguments can have multiple values. They have to be the last argument (Symfony enforces this). It is the same concept as [variadic functions](https://en.wikipedia.org/wiki/Variadic_function).

If the argument at the current word index doesn't exist it could be a second value for an array input argument. So we can just check and see if the last argument is an array and use it.