### PR TITLE
Allow Symfony4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,19 @@ language: php
 matrix:
   include:
     - php: 5.3
+      dist: precise
     - php: 5.4
     - php: 5.5
       env: COMPOSER_OPTS="--prefer-lowest"
     - php: 5.6
     - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: nightly
     - php: hhvm
+      env: COMPOSER_OPTS="--prefer-lowest"
+  allow_failures:
+    - php: nightly
 
 before_install:
   - sudo apt-get update -qq
@@ -19,4 +26,4 @@ install:
   - composer update $COMPOSER_OPTS
 
 script:
-  - phpunit tests
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/console": "~2.3 || ~3.0"
+        "symfony/console": "~2.3 || ~3.0 || ~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.36 || ~5.7 || ~6.4"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "symfony/console": "~2.3 || ~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4"
+        "phpunit/phpunit": "~4.8.36 || ~5.7 || ~6.4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/Common/CompletionHandlerTestCase.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/Common/CompletionHandlerTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Stecman\Component\Symfony\Console\BashCompletion\Tests\Common;
 
+use PHPUnit\Framework\TestCase;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionHandler;
 use Symfony\Component\Console\Application;
@@ -9,7 +10,7 @@ use Symfony\Component\Console\Application;
 /**
  * Base test case for running CompletionHandlers
  */
-abstract class CompletionHandlerTestCase extends \PHPUnit_Framework_TestCase
+abstract class CompletionHandlerTestCase extends TestCase
 {
     /**
      * @var Application

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionContextTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionContextTest.php
@@ -2,10 +2,11 @@
 
 namespace Stecman\Component\Symfony\Console\BashCompletion\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Stecman\Component\Symfony\Console\BashCompletion\EnvironmentCompletionContext;
 
-class CompletionContextTest extends \PHPUnit_Framework_TestCase
+class CompletionContextTest extends TestCase
 {
 
     public function testWordBreakSplit()

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/HookFactoryTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/HookFactoryTest.php
@@ -2,9 +2,10 @@
 
 namespace Stecman\Component\Symfony\Console\BashCompletion\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Stecman\Component\Symfony\Console\BashCompletion\HookFactory;
 
-class HookFactoryTest extends \PHPUnit_Framework_TestCase
+class HookFactoryTest extends TestCase
 {
     /**
      * @var HookFactory
@@ -91,9 +92,7 @@ class HookFactoryTest extends \PHPUnit_Framework_TestCase
 
             $status = proc_close($process);
 
-            if ($status !== 0) {
-                $this->fail("Syntax check for $context failed:\n$output");
-            }
+            $this->assertSame(0, $status, "Syntax check for $context failed:\n$output");
         } else {
             throw new \RuntimeException("Failed to start process with command '$syntaxCheckCommand'");
         }


### PR DESCRIPTION
This PR add support symfony-console-completion in projects that use console 4.0.0-BETA1  and(or) PHPUnit 5.7.

It seems safe to add  "minimum-stability": "beta" in master, after release it should be removed. Or you can pull the PR in separate branch to use for example `"stecman/symfony-console-completion": "dev-symfony4"` in composer.json for testing projects with beta without add forking repo to composer.json