### PR TITLE
Update PHP versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,15 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
     - php: 5.4
     - php: 5.5
       env: COMPOSER_OPTS="--prefer-lowest"
     - php: 5.6
     - php: 7.0
+    - php: 7.1
+    - php: 7.2
     - php: hhvm
+      env: COMPOSER_OPTS="--prefer-lowest"
 
 before_install:
   - sudo apt-get update -qq
@@ -19,4 +21,4 @@ install:
   - composer update $COMPOSER_OPTS
 
 script:
-  - phpunit tests
+  - vendor/bin/phpunit


### PR DESCRIPTION
5.3 unsupported by Travis CI now
7.2 is RC
HVVM is 5.6 based and I think that -prefer-lowest is enough nowadays