### PR TITLE
Rewrite command-line splitting to tokenize quoted strings

### DIFF
--- a/src/CompletionCommand.php
+++ b/src/CompletionCommand.php
@@ -76,7 +76,54 @@ END
             $output->write($hook, true);
         } else {
             $handler->setContext(new EnvironmentCompletionContext());
-            $output->write($this->runCompletion(), true);
+
+            // Get completion results
+            $results = $this->runCompletion();
+
+            // Escape results for the current shell
+            $shellType = $input->getOption('shell-type') ?: $this->getShellType();
+
+            foreach ($results as &$result) {
+                $result = $this->escapeForShell($result, $shellType);
+            }
+
+            $output->write($results, true);
+        }
+    }
+
+    /**
+     * Escape each completion result for the specified shell
+     *
+     * @param string $result - Completion results that should appear in the shell
+     * @param string $shellType - Valid shell type from HookFactory
+     * @return string
+     */
+    protected function escapeForShell($result, $shellType)
+    {
+        switch ($shellType) {
+            // BASH requires special escaping for multi-word and special character results
+            // This emulates registering completion with`-o filenames`, without side-effects like dir name slashes
+            case 'bash':
+                $context = $this->handler->getContext();
+                $wordStart = substr($context->getRawCurrentWord(), 0, 1);
+
+                if ($wordStart == "'") {
+                    // If the current word is single-quoted, escape any single quotes in the result
+                    $result = str_replace("'", "\\'", $result);
+                } else if ($wordStart == '"') {
+                    // If the current word is double-quoted, escape any double quotes in the result
+                    $result = str_replace('"', '\\"', $result);
+                } else {
+                    // Otherwise assume the string is unquoted and word breaks should be escaped
+                    $result = preg_replace('/([\s\'"\\\\])/', '\\\\$1', $result);
+                }
+
+                // Escape output to prevent special characters being lost when passing results to compgen
+                return escapeshellarg($result);
+
+            // No transformation by default
+            default:
+                return $result;
         }
     }
 

--- a/src/HookFactory.php
+++ b/src/HookFactory.php
@@ -41,6 +41,9 @@ function %%function_name%% {
 
     local RESULT STATUS;
 
+    # Force splitting by newline instead of default delimiters
+    local IFS=$'\n'
+
     RESULT="$(%%completion_command%% </dev/null)";
     STATUS=$?;
 
@@ -64,6 +67,11 @@ function %%function_name%% {
     fi;
 
     COMPREPLY=(`compgen -W "$RESULT" -- $cur`);
+
+    # Escape any spaces in results if the current word doesn't begin with a quote
+    if [[ ! -z $COMPREPLY  ]] && [[ ! $cur =~ ^[\'\"] ]]; then
+        COMPREPLY=($(printf '%q\n' "${COMPREPLY[@]}"));
+    fi;
 
     __ltrim_colon_completions "$cur";
 

--- a/src/HookFactory.php
+++ b/src/HookFactory.php
@@ -68,11 +68,6 @@ function %%function_name%% {
 
     COMPREPLY=(`compgen -W "$RESULT" -- $cur`);
 
-    # Escape any spaces in results if the current word doesn't begin with a quote
-    if [[ ! -z $COMPREPLY  ]] && [[ ! $cur =~ ^[\'\"] ]]; then
-        COMPREPLY=($(printf '%q\n' "${COMPREPLY[@]}"));
-    fi;
-
     __ltrim_colon_completions "$cur";
 
     MAILCHECK=mail_check_backup;
@@ -155,6 +150,9 @@ END
         } else {
             $completionCommand = $programPath . ' _completion';
         }
+
+        // Pass shell type during completion so output can be encoded if the shell requires it
+        $completionCommand .= " --shell-type $type";
 
         return str_replace(
             array(

--- a/src/HookFactory.php
+++ b/src/HookFactory.php
@@ -57,7 +57,8 @@ function %%function_name%% {
     # Check if shell provided path completion is requested
     # @see Completion\ShellPathCompletion
     if [ $STATUS -eq 200 ]; then
-        _filedir;
+        # Turn file/dir completion on temporarily and give control back to BASH
+        compopt -o default;
         return 0;
 
     # Bail out if PHP didn't exit cleanly

--- a/src/HookFactory.php
+++ b/src/HookFactory.php
@@ -33,16 +33,16 @@ function %%function_name%% {
 
     # Copy BASH's completion variables to the ones the completion command expects
     # These line up exactly as the library was originally designed for BASH
-    local CMDLINE_CONTENTS="$COMP_LINE"
-    local CMDLINE_CURSOR_INDEX="$COMP_POINT"
+    local CMDLINE_CONTENTS="$COMP_LINE";
+    local CMDLINE_CURSOR_INDEX="$COMP_POINT";
     local CMDLINE_WORDBREAKS="$COMP_WORDBREAKS";
 
-    export CMDLINE_CONTENTS CMDLINE_CURSOR_INDEX CMDLINE_WORDBREAKS
+    export CMDLINE_CONTENTS CMDLINE_CURSOR_INDEX CMDLINE_WORDBREAKS;
 
     local RESULT STATUS;
 
     # Force splitting by newline instead of default delimiters
-    local IFS=$'\n'
+    local IFS=$'\n';
 
     RESULT="$(%%completion_command%% </dev/null)";
     STATUS=$?;
@@ -78,19 +78,19 @@ if [ "$(type -t _get_comp_words_by_ref)" == "function" ]; then
 else
     >&2 echo "Completion was not registered for %%program_name%%:";
     >&2 echo "The 'bash-completion' package is required but doesn't appear to be installed.";
-fi
+fi;
 END
 
         // ZSH Hook
         , 'zsh' => <<<'END'
 # ZSH completion for %%program_path%%
 function %%function_name%% {
-    local -x CMDLINE_CONTENTS="$words"
-    local -x CMDLINE_CURSOR_INDEX
-    (( CMDLINE_CURSOR_INDEX = ${#${(j. .)words[1,CURRENT]}} ))
+    local -x CMDLINE_CONTENTS="$words";
+    local -x CMDLINE_CURSOR_INDEX;
+    (( CMDLINE_CURSOR_INDEX = ${#${(j. .)words[1,CURRENT]}} ));
 
-    local RESULT STATUS
-    RESULT=("${(@f)$( %%completion_command%% )}")
+    local RESULT STATUS;
+    RESULT=("${(@f)$( %%completion_command%% )}");
     STATUS=$?;
 
     # Check if shell provided path completion is requested
@@ -105,7 +105,7 @@ function %%function_name%% {
         return $?;
     fi;
 
-    compadd -- $RESULT
+    compadd -- $RESULT;
 };
 
 compdef %%function_name%% "%%program_name%%";

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionContextTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionContextTest.php
@@ -92,6 +92,44 @@ class CompletionContextTest extends TestCase
         $this->assertEquals('', $context->getCurrentWord());
     }
 
+    public function testQuotedStringWordBreaking()
+    {
+        $context = new CompletionContext();
+        $context->setCharIndex(1000);
+        $context->setCommandLine('make horse --legs=3 --name="Jeff the horse" --colour Extreme\ Blanc \'foo " bar\'');
+
+        // Ensure spaces and quotes
+        $this->assertEquals(
+            array(
+                'make',
+                'horse',
+                '--legs',
+                '3',
+                '--name',
+                'Jeff the horse',
+                '--colour',
+                'Extreme Blanc',
+                'foo " bar',
+                '',
+            ),
+            $context->getWords()
+        );
+
+        $context = new CompletionContext();
+        $context->setCommandLine('console --tag=');
+
+        // Cursor after equals symbol on option argument
+        $context->setCharIndex(14);
+        $this->assertEquals(
+            array(
+                'console',
+                '--tag',
+                ''
+            ),
+            $context->getWords()
+        );
+    }
+
     public function testConfigureFromEnvironment()
     {
         putenv("CMDLINE_CONTENTS=beam up li");

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionContextTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionContextTest.php
@@ -96,9 +96,9 @@ class CompletionContextTest extends TestCase
     {
         $context = new CompletionContext();
         $context->setCharIndex(1000);
-        $context->setCommandLine('make horse --legs=3 --name="Jeff the horse" --colour Extreme\ Blanc \'foo " bar\'');
+        $context->setCommandLine('make horse --legs=3 --name="Jeff the horse" --colour Extreme\\ Blanc \'foo " bar\'');
 
-        // Ensure spaces and quotes
+        // Ensure spaces and quotes are processed correctly
         $this->assertEquals(
             array(
                 'make',
@@ -115,6 +115,23 @@ class CompletionContextTest extends TestCase
             $context->getWords()
         );
 
+        // Confirm the raw versions of the words are indexed correctly
+        $this->assertEquals(
+            array(
+                'make',
+                'horse',
+                '--legs',
+                '3',
+                '--name',
+                '"Jeff the horse"',
+                '--colour',
+                'Extreme\\ Blanc',
+                "'foo \" bar'",
+                '',
+            ),
+            $context->getRawWords()
+        );
+
         $context = new CompletionContext();
         $context->setCommandLine('console --tag=');
 
@@ -128,6 +145,18 @@ class CompletionContextTest extends TestCase
             ),
             $context->getWords()
         );
+    }
+
+    public function testGetRawCurrentWord()
+    {
+        $context = new CompletionContext();
+
+        $context->setCommandLine('cmd "double quoted" --option \'value\'');
+        $context->setCharIndex(13);
+        $this->assertEquals(1, $context->getWordIndex());
+
+        $this->assertEquals(array('cmd', '"double q', '--option', "'value'"), $context->getRawWords());
+        $this->assertEquals('"double q', $context->getRawCurrentWord());
     }
 
     public function testConfigureFromEnvironment()

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
@@ -80,6 +80,21 @@ class CompletionHandlerTest extends CompletionHandlerTestCase
         $this->assertArraySubset(array('--jazz-hands'), $this->getTerms($handler->runCompletion()));
     }
 
+    public function testCompleteOptionEqualsValue()
+    {
+        // Cursor at the "=" sign
+        $handler = $this->createHandler('app completion-aware --option-with-suggestions=');
+        $this->assertEquals(array('one-opt', 'two-opt'), $this->getTerms($handler->runCompletion()));
+
+        // Cursor at an opening quote
+        $handler = $this->createHandler('app completion-aware --option-with-suggestions="');
+        $this->assertEquals(array('one-opt', 'two-opt'), $this->getTerms($handler->runCompletion()));
+
+        // Cursor inside a quote with value
+        $handler = $this->createHandler('app completion-aware --option-with-suggestions="two');
+        $this->assertEquals(array('two-opt'), $this->getTerms($handler->runCompletion()));
+    }
+
     public function testCompleteOptionOrder()
     {
         // Completion of options should be able to happen anywhere after the command name


### PR DESCRIPTION
This replaces the previous simple "split on breaks" regex in `CompletionContext::splitCommand()` with a function that behaves as a tokenizer and uses a more complete regex.

This adds support for completion of:

- Escaped spaces (and other characters): `Some\ multi\ word\ sequence`
- Quoted strings: `"have some double quotes"` / `'you\'ll get single quotes too'`
- ~`=""` style options: `--foo="bar"`~ (couldn't repro this working)

**To do:**

- [x] Add support for output of quoted/escaped strings during completion. This first commit adds the input side only - a completion for a multi word string incorrectly results in multiple suggestions at the moment. Either need to keep state of which word indexes were quoted, or just automatically quote/escape all suggestions for shell output.

Resolves #67 