### PR TITLE
remove command shortcuts

### DIFF
--- a/src/CompletionCommand.php
+++ b/src/CompletionCommand.php
@@ -122,19 +122,19 @@ END
         return new InputDefinition(array(
             new InputOption(
                 'generate-hook',
-                'g',
+                null,
                 InputOption::VALUE_NONE,
                 'Generate BASH code that sets up completion for this application.'
             ),
             new InputOption(
                 'program',
-                'p',
+                null,
                 InputOption::VALUE_REQUIRED,
                 "Program name that should trigger completion\n<comment>(defaults to the absolute application path)</comment>."
             ),
             new InputOption(
                 'multiple',
-                'm',
+                null,
                 InputOption::VALUE_NONE,
                 "Generated hook can be used for multiple applications."
             ),


### PR DESCRIPTION
Hi, i use this nice tool for my command line app. This app has many global arguments (for all commands) with shortcuts.

Now i cant use this package, because the auto complete command uses the same shortcuts.

I think the most common usecase for shortcuts is for applications, that use this package :)
so, can them removed?