### PR TITLE
Add support for Symfony 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/console": "~2.3 || ~3.0 || ~4.0"
+        "symfony/console": "~2.3 || ~3.0 || ~4.0 || ~5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.36 || ~5.7 || ~6.4"

--- a/src/CompletionCommand.php
+++ b/src/CompletionCommand.php
@@ -134,6 +134,8 @@ END
 
             $output->write($results, true);
         }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Optional support for Symfony 5.0.
Changed return argument of `CompletionCommand::execute`. 

#SymfonyHackday