### PR TITLE
Escape the program path in the completion command

### DIFF
--- a/src/HookFactory.php
+++ b/src/HookFactory.php
@@ -147,9 +147,9 @@ END
         $programName = $programName ?: $programPath;
 
         if ($multiple) {
-            $completionCommand = '$1 _completion';
+            $completionCommand = '"$1" _completion';
         } else {
-            $completionCommand = $programPath . ' _completion';
+            $completionCommand = escapeshellarg($programPath) . ' _completion';
         }
 
         // Pass shell type during completion so output can be encoded if the shell requires it


### PR DESCRIPTION
It seems that if the program path contains spaces then the completion will fail.

Draft while manually testing.