### PR TITLE
Support Symfony 6 and php 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
     ],
     "require": {
         "php": ">=8.0.2",
-        "symfony/console": "~6.0",
+        "symfony/console": "~6.0"
+    },
+    "require-dev": {
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
-        "symfony/console": "~2.3 || ~3.0 || ~4.0 || ~5.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "~4.8.36 || ~5.7 || ~6.4"
+        "php": ">=8.0.2",
+        "symfony/console": "~6.0",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/CompletionCommand.php
+++ b/src/CompletionCommand.php
@@ -43,7 +43,7 @@ END
     /**
      * {@inheritdoc}
      */
-    public function getNativeDefinition()
+    public function getNativeDefinition(): InputDefinition
     {
         return $this->createDefinition();
     }

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/Common/CompletionHandlerTestCase.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/Common/CompletionHandlerTestCase.php
@@ -17,7 +17,7 @@ abstract class CompletionHandlerTestCase extends TestCase
      */
     protected $application;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         require_once __DIR__ . '/../Fixtures/CompletionAwareCommand.php';
         require_once __DIR__ . '/../Fixtures/HiddenCommand.php';
@@ -25,7 +25,7 @@ abstract class CompletionHandlerTestCase extends TestCase
         require_once __DIR__ . '/../Fixtures/TestSymfonyStyleCommand.php';
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->application = new Application('Base application');
         $this->application->addCommands(array(

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/HookFactoryTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/HookFactoryTest.php
@@ -12,7 +12,7 @@ class HookFactoryTest extends TestCase
      */
     protected $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new HookFactory();
     }


### PR DESCRIPTION
Seems Symfony 6 changed method return type, so we are unable to support older version.