### PR TITLE
Bump min symfony/console version to 6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=8.0.2",
-        "symfony/console": "~6.0"
+        "symfony/console": "~6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
502e2699144a0c39ee51271d18bcf57b0202ab43 introduced a breaking change that requires `symfony/console:^6.3`, but the current `symfony/console` constraint (`~6.0`) allows previous versions. Using this package with `symfony/console` < 6.3 will result in the following error:

```
Fatal error: Declaration of Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand::mergeApplicationDefinition($mergeArgs = true) must be compatible with Symfony\Component\Console\Command\Command::mergeApplicationDefinition(bool $mergeArgs = true): void
```

This PR ensures that the minimum compatible version of Symfony Console (6.3) is installed.