### PR TITLE
Provide support of symfony/console 7.x for Drupal 11 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=8.0.2",
-        "symfony/console": "~6.3"
+        "symfony/console": "~6.3 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/src/CompletionCommand.php
+++ b/src/CompletionCommand.php
@@ -15,15 +15,13 @@ class CompletionCommand extends SymfonyCommand
      */
     protected $handler;
 
-    /**
-     *  Bash completion command description.
-     */
-    protected static $defaultDescription = 'BASH completion hook.';
 
     protected function configure()
     {
         $this
             ->setName('_completion')
+            ->setDefinition($this->createDefinition())
+            ->setDescription('BASH completion hook.')
             ->setHelp(<<<END
 To enable BASH completion, run:
 

--- a/src/CompletionCommand.php
+++ b/src/CompletionCommand.php
@@ -15,12 +15,15 @@ class CompletionCommand extends SymfonyCommand
      */
     protected $handler;
 
+    /**
+     *  Bash completion command description.
+     */
+    protected static $defaultDescription = 'BASH completion hook.';
+
     protected function configure()
     {
         $this
             ->setName('_completion')
-            ->setDefinition($this->createDefinition())
-            ->setDescription('BASH completion hook.')
             ->setHelp(<<<END
 To enable BASH completion, run:
 
@@ -51,7 +54,7 @@ END
      * Any global options defined by user-code are meaningless to this command.
      * Options outside of the core defaults are ignored to avoid name and shortcut conflicts.
      */
-    public function mergeApplicationDefinition($mergeArgs = true): void
+    public function mergeApplicationDefinition(bool $mergeArgs = true): void
     {
         // Get current application options
         $appDefinition = $this->getApplication()->getDefinition();
@@ -91,7 +94,7 @@ END
         });
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->handler = new CompletionHandler($this->getApplication());
         $handler = $this->handler;
@@ -132,7 +135,7 @@ END
             $output->write($results, true);
         }
 
-        return 0;
+        return (int) SymfonyCommand::SUCCESS;
     }
 
     /**

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/Common/CompletionHandlerTestCase.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/Common/CompletionHandlerTestCase.php
@@ -30,6 +30,7 @@ abstract class CompletionHandlerTestCase extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->application = new Application('Base application');
         $this->application->addCommands(array(
             new \CompletionAwareCommand(),

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/CompletionHandlerTest.php
@@ -143,7 +143,7 @@ class CompletionHandlerTest extends CompletionHandlerTestCase
         $this->assertSame($suggestions, $this->getTerms($handler->runCompletion()));
     }
 
-    public function completionAwareCommandDataProvider()
+    public static function completionAwareCommandDataProvider(): array
     {
         return array(
             'not complete aware command' => array('app wave --vigorous ', array()),

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/Fixtures/HiddenCommand.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/Fixtures/HiddenCommand.php
@@ -1,7 +1,8 @@
 <?php
 
+use Symfony\Component\Console\Command\Command;
 
-class HiddenCommand extends \Symfony\Component\Console\Command\Command
+class HiddenCommand extends Command
 {
     protected function configure()
     {

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/Fixtures/TestBasicCommand.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/Fixtures/TestBasicCommand.php
@@ -1,7 +1,10 @@
 <?php
 
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 
-class TestBasicCommand extends \Symfony\Component\Console\Command\Command
+class TestBasicCommand extends Command
 {
     protected function configure()
     {
@@ -16,11 +19,11 @@ class TestBasicCommand extends \Symfony\Component\Console\Command\Command
             ->addOption(
                 'style',
                 's',
-                \Symfony\Component\Console\Input\InputOption::VALUE_REQUIRED
+                InputOption::VALUE_REQUIRED
             )
             ->addArgument(
                 'target',
-                \Symfony\Component\Console\Input\InputArgument::REQUIRED
+                InputArgument::REQUIRED
             );
     }
 }

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/Fixtures/TestSymfonyStyleCommand.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/Fixtures/TestSymfonyStyleCommand.php
@@ -1,6 +1,9 @@
 <?php
 
-class TestSymfonyStyleCommand extends \Symfony\Component\Console\Command\Command
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+class TestSymfonyStyleCommand extends Command
 {
     protected function configure()
     {
@@ -16,12 +19,12 @@ class TestSymfonyStyleCommand extends \Symfony\Component\Console\Command\Command
             ->addOption(
                 'style',
                 's',
-                \Symfony\Component\Console\Input\InputOption::VALUE_REQUIRED
+                InputOption::VALUE_REQUIRED
             )
             ->addOption(
                 'target',
                 't',
-                \Symfony\Component\Console\Input\InputOption::VALUE_REQUIRED
+                InputOption::VALUE_REQUIRED
             );
     }
 }

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/HookFactoryTest.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/HookFactoryTest.php
@@ -14,6 +14,7 @@ class HookFactoryTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->factory = new HookFactory();
     }
 
@@ -43,7 +44,7 @@ class HookFactoryTest extends TestCase
         }
     }
 
-    public function generateHookDataProvider()
+    public static function generateHookDataProvider()
     {
         return array(
             array('/path/to/myprogram', null, false),


### PR DESCRIPTION
With the upcoming release of Drupal 11, it is important to note that the symfony-console-completion package cannot be required, as it is only compatible with symfony/console version 6.x. Since Drupal 11 necessitates symfony/console version 7.x. Update required.