### PR TITLE
fix: Make $context explicitly nullable

### DIFF
--- a/src/CompletionHandler.php
+++ b/src/CompletionHandler.php
@@ -40,7 +40,7 @@ class CompletionHandler
      */
     private $commandWordIndex;
 
-    public function __construct(Application $application, CompletionContext $context = null)
+    public function __construct(Application $application, ?CompletionContext $context = null)
     {
         $this->application = $application;
         $this->context = $context;

--- a/src/HookFactory.php
+++ b/src/HookFactory.php
@@ -126,10 +126,10 @@ END
     /**
      * Return a completion hook for the specified shell type
      *
-     * @param string $type - a key from self::$hooks
-     * @param string $programPath
-     * @param string $programName
-     * @param bool   $multiple
+     * @param string  $type - a key from self::$hooks
+     * @param string  $programPath
+     * @param ?string $programName
+     * @param bool    $multiple
      *
      * @return string
      */

--- a/tests/Stecman/Component/Symfony/Console/BashCompletion/Common/CompletionHandlerTestCase.php
+++ b/tests/Stecman/Component/Symfony/Console/BashCompletion/Common/CompletionHandlerTestCase.php
@@ -47,7 +47,7 @@ abstract class CompletionHandlerTestCase extends TestCase
      * Create a handler set up with the given commandline and cursor position
      *
      * @param $commandLine
-     * @param int $cursorIndex
+     * @param ?int $cursorIndex
      * @return CompletionHandler
      */
     protected function createHandler($commandLine, $cursorIndex = null)


### PR DESCRIPTION


Solves the following deprecation with PHP 8.4:
> PHP Deprecated:  Stecman\Component\Symfony\Console\BashCompletion\CompletionHandler::__construct(): Implicitly marking parameter $context as nullable is deprecated, the explicit nullable type must be used instead in /home/nickv/Nextcloud/31/server/3rdparty/stecman/symfony-console-completion/src/CompletionHandler.php on line 43